### PR TITLE
Only access slots mentioned in the match.

### DIFF
--- a/src/pattern.lisp
+++ b/src/pattern.lisp
@@ -214,14 +214,14 @@ Examples:
     (awhen (first (set-difference (mapcar #'car slot-patterns) slot-names))
       (error "Unknown slot name ~A for ~A" it class-name))
     (let ((arguments
-            (loop for slot-name in slot-names
-                  for slot-pattern = (assoc slot-name slot-patterns)
-                  collect
-                  (if slot-pattern
-                      (if (cdr slot-pattern)
-                          (parse-pattern `(and ,@(cdr slot-pattern)))
-                          (make-bind-pattern (car slot-pattern)))
-                      (make-variable-pattern))))
+            (loop
+               for slot-name in slot-names
+               for slot-pattern = (assoc slot-name slot-patterns)
+               when slot-pattern
+               collect
+                 (if (cdr slot-pattern)
+                     (parse-pattern `(and ,@(cdr slot-pattern)))
+                     (make-bind-pattern (car slot-pattern)))))
           (predicate (lambda (var) `(typep ,var ',class-name)))
           (accessor (lambda (var i) `(slot-value ,var ',(nth i slot-names)))))
       (make-constructor-pattern :signature `(,class-name ,(length arguments))


### PR DESCRIPTION
Slots are not necessarily bound. Prior to this patch, all slots were
involved in a match, regardless of whether they were mentioned in the
pattern. Thus, the following code failed with SLOT-UNBOUND:

(defclass foo () (x))

(match (make-instance 'foo)
  ((class foo) (print "Hooray, we got a foo!")))

The above code should now work as expected.

It may be prudent to add a SLOT-UNBOUND subpattern for slots, to match
instances when given slots are unbound. At the same time, this is already
possible through guards:

(match (make-instance 'foo)
  ((and instance (class foo) (when (not (slot-boundp instance 'x))))
   (print "unbound!")))

So it's not that big a deal.
