### PR TITLE
Fix LIST* pattern when used with one subpattern

### DIFF
--- a/src/pattern.lisp
+++ b/src/pattern.lisp
@@ -378,12 +378,9 @@ Examples:
     `(cons ,(car args) (list ,@(cdr args)))))
 
 (defpattern list* (arg &rest args)
-  `(cons ,arg
-         ,(cond ((null args))
-                ((= (length args) 1)
-                 (car args))
-                (t
-                 `(list* ,(car args) ,@(cdr args))))))
+  (if (null args)
+      `(and ,arg (type list))
+      `(cons ,arg (list* ,@args))))
 
 (defpattern satisfies (predicate-name)
   (with-unique-names (it)

--- a/test/suite.lisp
+++ b/test/suite.lisp
@@ -133,9 +133,15 @@
 
 (test derived-pattern
   ;; list
+  (is-match '() (list))
   (is-match '(1 2 3) (list 1 2 3))
+  (is-not-match '() (list _))
+  (is-not-match 5 (list _))
   ;; list*
+  (is-match '() (list* _))
   (is-match '(1 2 3) (list* 1 2 (list 3)))
+  (is-match '(1 2 3) (list* _))
+  (is-not-match 5 (list* _))
   ;; alist
   (is-match '((1 . 2) (2 . 3) (3 . 4)) (alist (3 . 4) (1 . 2)))
   ;; plist


### PR DESCRIPTION
Previously, the `list*` pattern when used with one subpattern did not match lists.

The patch changes that behavior such that

``` cl
(ematch 5 ((list* l) l)) |- ERROR

(ematch '()) ((list* l) l)) => ()
(ematch '(1) ((list* l) l)) => (1)
(ematch '(1 2) ((list* l) l)) => (1 2)
(ematch '(1 2 3) ((list* l) l)) => (1 2 3)

(ematch (list* '(1 2 3)) ((list* l) l)) => (1 2 3) 
;; (list* LIST) == LIST but this illustrates the relation between the function and the pattern constructor
```
