### PR TITLE
Fix unparsing of constant patterns consisting of symbols

### DIFF
--- a/src/pattern.lisp
+++ b/src/pattern.lisp
@@ -527,9 +527,13 @@ Examples:
 
 (defmethod unparse-pattern ((pattern constant-pattern))
   (with-slots (value) pattern
-    (if (atom value)
-        value
-        `(quote ,value))))
+    (cond
+      ((typep value '(and symbol (not keyword) (not (member nil t))))
+       `(quote ,value))
+      ((atom value)
+       value)
+      (t
+       `(quote ,value)))))
 
 (defmethod unparse-pattern ((pattern guard-pattern))
   `(guard ,(unparse-pattern (guard-pattern-subpattern pattern))

--- a/test/suite.lisp
+++ b/test/suite.lisp
@@ -1,10 +1,35 @@
 (defpackage :optima.test
   (:use :cl :eos :optima :optima.extra :optima.ppcre)
+  (:import-from :optima.core #:parse-pattern #:unparse-pattern)
   (:shadowing-import-from :optima #:fail))
 (in-package :optima.test)
 
 (def-suite optima-test)
 (in-suite optima-test)
+
+;;; Pattern syntax
+
+(test roundtrip
+  (macrolet
+      ((check-roundtrip (pattern)
+         `(is (equal ',pattern
+                     (unparse-pattern (parse-pattern ',pattern))))))
+    ;; constant
+    (check-roundtrip 1)
+    (check-roundtrip t)
+    (check-roundtrip nil)
+    (check-roundtrip :foo)
+    (check-roundtrip 3.14)
+    (check-roundtrip "foo")
+    (check-roundtrip 'x)
+    (check-roundtrip '(x . y))
+    (check-roundtrip '(x y))
+    (check-roundtrip '(1 :foo))
+    ;; variable
+    ; (check-roundtrip _) does not roundtrip, but that's probably OK.
+    (check-roundtrip x)))
+
+;;; Pattern matching
 
 (defmacro is-match (arg pattern)
   `(is-true (match ,arg (,pattern t))))


### PR DESCRIPTION
Quoted symbols did not roundtrip through

```
PARSE-PATTERN -> UNPARSE-PATTERN
```

because they were unparsed without `quote`. I.e.

``` cl
(unparse-pattern (parse-pattern ''x))
=> X instead of (QUOTE X)
```

This change causes all symbols except keywords, `t` and `nil` to be unparsed
with `quote`.
