### PR TITLE
If necessary, call FINALIZE-INHERITANCE when parsing CLASS patterns

### DIFF
--- a/test/suite.lisp
+++ b/test/suite.lisp
@@ -90,7 +90,6 @@
   (defclass person ()
     ((name :initarg :name)
      (age :initarg :age)))
-  (closer-mop:finalize-inheritance (find-class 'person))
 
   (defstruct (point (:predicate point-p))
     x y))


### PR DESCRIPTION
Remove manual call to FINALIZE-INHERITANCE in test suite.

fixes #96
