### PR TITLE
Introducing binding-pattern

### DIFF
--- a/optima.asd
+++ b/optima.asd
@@ -402,6 +402,7 @@ See the source code for more detail."
                              (:file "util")
                              (:file "runtime")
                              (:file "pattern")
+                             (:file "binding-pattern")
                              (:file "fail")
                              (:file "compiler")
                              (:file "match")

--- a/src/binding-pattern.lisp
+++ b/src/binding-pattern.lisp
@@ -1,0 +1,50 @@
+
+
+(in-package :optima)
+
+(defstruct (<>-pattern
+            (:include constructor-pattern)
+            (:constructor make-<>-pattern
+                          (name arg value &aux (subpatterns (list name)))))
+  name arg value)
+
+(defmethod constructor-pattern-destructor-sharable-p
+    ((x <>-pattern) (y <>-pattern))
+  nil)
+
+(defmethod constructor-pattern-make-destructor
+    ((pattern <>-pattern) matched)
+  (with-slots (arg value) pattern
+     (make-destructor
+      :bindings `((,arg ,matched))
+      :predicate-form t
+      :accessor-forms `(,value))))
+
+(defmethod unparse-pattern ((pattern <>-pattern))
+  (with-slots (name arg value) pattern
+     `(<> ,name ,arg ,value)))
+
+(defmethod parse-constructor-pattern ((name (eql '<>)) &rest args)
+  (match args
+    ((list name (and arg (symbol)) value)
+     (make-<>-pattern (parse-pattern name) arg value))
+    (otherwise
+     (error "Bad binding pattern: ~S" (list* name args)))))
+
+#+nil
+(match 'x
+  ((<> a 3)
+   (print a)))
+
+#+nil
+(defpattern cons (a b)
+  (let ((x gensym))
+    `(and (type cons)
+          (<> a ,x (car ,x))
+          (<> b ,x (cdr ,x)))))
+
+#+nil
+(defpattern function-type (return-type)
+  `(or (and 'function (<> ,return-type _ '*))
+       (and (list 'function _ ,return-type))))
+

--- a/src/packages.lisp
+++ b/src/packages.lisp
@@ -142,7 +142,8 @@
            #:place
            #:guard
            #:property
-           #:defpattern))
+           #:defpattern
+           #:<>))
 
 (defpackage :optima.extra
   (:use :cl :optima)


### PR DESCRIPTION
# introduction

binding-pattern `(<> pattern arg value)` works just as `let`. the value to be matched is put into `arg`. `value` evaluates and returns some value, then the return value is matched against `pattern`.

Consider you want to write a query that matches the type specifier `function`, and destruct it into the types of arguments and the types of return values.

```list
(defpattern function-type (argument-types return-type)
  `(list 'function ,argument-types ,return-type))

(ematch '(function () fixnum)
   ((function-type args values) values)))
;; --> 'fixnum
```

This is not sufficient, because Common lisp allows "dropping" the type specifier arguments. e.g. `function`, `(function)`, `(function ())`, `(function () (values &rest *))` are all valid type specifiers.

```lisp
(ematch 'function
   ((function-type args values) values)))
; --> error
```

Ideally, above code should work as below, since the default type for function return value is `*`.

```lisp
(match 'function
   ((function-type args values) values)))
; -->  '*
```

# background

One currently approved methodology to achieve this effect is to use the optima's internal functions and structures. To implement such a pattern, we have to implement all these structure and  methods below. THIS IS AWFUL.

```lisp
(defstruct (function-type-pattern
            (:include constructor-pattern)
            (:constructor make-function-type-pattern
                          (arguments value &aux (subpatterns (list arguments value)))))
  arguments value)

(defmethod constructor-pattern-destructor-sharable-p
    ((x function-type-pattern) (y function-type-pattern))
  t)

(defmethod constructor-pattern-make-destructor
    ((pattern function-type-pattern) matched)
  (with-slots (arguments value) pattern
     (make-destructor
      :bindings <<too complecated WTF>>
      :predicate-form <<too complecated WTF>>
      :accessor-forms <<too complecated WTF>>)))

(defmethod unparse-pattern ((pattern function-type-pattern))
  (with-slots (arguments value) pattern
     `(function-type ,arguments ,value)))

(defmethod parse-constructor-pattern ((name (eql 'function-type)) &rest args)
  (match args
    ((list arguments value)
     (make-function-type-pattern (mapcar #'parse-pattern arguments) (parse-pattern value)))
    (otherwise
     (error "Bad function-type pattern: ~S" (list* name args)))))
```

THIS IS AWFUL.

# binding-pattern

Now we introduce a binding pattern. It can bind arbitrary value obtained from the matched element, then assign it against the subpattern.

```lisp
(defpattern function-type (argument-types return-type)
  (let ((x gensym))
  `(or (and 'function (<> ,argument-types ,x '(&rest *)) (<> ,return-type ,x '*))
         ; x is not used, since it binds a constant
       (and (list 'function ,argument-types) (<> ,return-type ,x '*))
       (and (list 'function ,argument-types ,return-type)))

(match 'function
   ((function-type args values) values)))
; --> '*
```

This is a refinement of the previous posts about accessor-pattern in #90. for example, `cons` pattern, currently implemented with native `constructure-pattern`, can be implemented as below:

```lisp
(defpattern cons (a b)
  (let ((x gensym))
    `(and (type cons)
          (<> ,a ,x (car ,x))
          (<> ,b ,x (cdr ,x)))))
```

# Related works

Providing accessors and use the feature in optima that parse the structure pattern prefix like `(foo- bar)` and `(defun foo-bar ()...)` and `(defun foo-p () ...)` is another way around, but binding-pattern supersedes this idea. By separating `foo-p` and `foo-bar`, it only results in redundunt and inefficient code. Consider the following example:

```lisp
(defun function-type-p (type)
  (or (eq 'function type)
      (and (cons type)
           (eq (first type) 'function)
           ...)))

(defun function-type-arguments (type)
  (cond
    ((eq 'function type) '*)
    ((and (cons type)
          (eq (first type) 'function)
           ...))))
```

It runs the same destructuing twice and ineffficient. The approache should be in reverse --- Actually, it should be the pattern that defines an accessor. For example, using a macro like `defpattern-with-accessors`, we can write:

```lisp
(defpattern-with-accessors function-type (args-types return-type)
  ...)

;; -->

(PROGN
  (DEFPATTERN FUNCTION-TYPE
      (&OPTIONAL (ARGS-TYPES '_) (RETURN-TYPE '_))
    `(OR (AND 'FUNCTION (<> ,ARGS-TYPES _ '(&REST *)) (<> ,,RETURN-TYPE _ '*))
         (OR (AND (LIST 'FUNCTION ,ARGS-TYPES ,RETURN-TYPE)) (AND (LIST 'FUNCTION ,ARGS-TYPES) (<> ,RETURN-TYPE _ '*))
             (AND (LIST 'FUNCTION) (<> ,ARGS-TYPES _ '(&REST *)) (<> ,RETURN-TYPE _ '*)))))
 (DEFUN FUNCTION-TYPE-ARGS-TYPES (#:OBJ1737)
   (MATCH #:OBJ1737
     ((FUNCTION-TYPE ARGS-TYPES _) ARGS-TYPES)))
 (DEFUN FUNCTION-TYPE-RETURN-TYPE (#:OBJ1737)
   (MATCH #:OBJ1737
     ((FUNCTION-TYPE _ RETURN-TYPE) RETURN-TYPE)))
 (DEFUN FUNCTION-TYPE-P (#:OBJ1737)
   (MATCH #:OBJ1737
     ((FUNCTION-TYPE) T)
     (_ NIL))))
```

https://github.com/Bike/compiler-macro provides sufficiently smart type extraction, and I am refactoring their functions with optima. However, given that lots of custom patterns should be written using optima's internal structure, for each of type specifiers in common lisp, like `array`, `(array fixnum (*))` etc, it is almost impossible to achieve this without binding-type.

