### PR TITLE
Chamge list* pattern to match how the fn works

### DIFF
--- a/src/pattern.lisp
+++ b/src/pattern.lisp
@@ -379,7 +379,7 @@ Examples:
 
 (defpattern list* (arg &rest args)
   (if (null args)
-      `(and ,arg (type list))
+      `,arg
       `(cons ,arg (list* ,@args))))
 
 (defpattern satisfies (predicate-name)

--- a/test/suite.lisp
+++ b/test/suite.lisp
@@ -165,7 +165,9 @@
   (is-match '() (list* _))
   (is-match '(1 2 3) (list* 1 2 (list 3)))
   (is-match '(1 2 3) (list* _))
-  (is-not-match 5 (list* _))
+  (is-match 5 (list* _))
+  (is-match '(1 2 . 3) (list* _ _ _))
+  (is-not-match '(1 2 . 3) (list* _ _ _ _))
   ;; alist
   (is-match '((1 . 2) (2 . 3) (3 . 4)) (alist (3 . 4) (1 . 2)))
   ;; plist


### PR DESCRIPTION
e.g. `(list* 5) => 5` so `(match 5 ((list* x) x)) => 5`

and

`(list* 1 2 3) => (1 2 . 3)` so `(match '(1 2 . 3) ((list* a b c) (list a b c) => (1 2 3)`

This fixes issue #115 which was introuced by #97
