### PR TITLE
fix docstring for `match`

### DIFF
--- a/src/match.lisp
+++ b/src/match.lisp
@@ -47,7 +47,7 @@ Examples:
     (match 1 (1 1))
     => 1
     (match 1 (2 2))
-    => 2
+    => NIL
     (match 1 (x x))
     => 1
     (match (list 1 2 3)


### PR DESCRIPTION
In the second example provided in the `match` docstring, `1` fails to match `2` and so the whole form evaluates to `NIL`.

Sorry to have picked a boring branch name.